### PR TITLE
Fix Linux builds && Node version && add Windows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: '20'
       - run: | 
+          sudo apt update && sudo apt install p7zip-full nsis
           CLI_VERSION=${{ steps.set-version.outputs.version }} node cli/.ci/set-package-vars.js
           CI_CD_BUILD=1 cli/.ci/package.sh
       - name: Archive artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           name: Linux
           path: |
-            cli/dist/deb
+            cli/tmp/artifacts
 
   build-on-macos:
     name: Build, sign and notarize .pkg files for Mac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           fi
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       - run: | 
           CLI_VERSION=${{ steps.set-version.outputs.version }} node cli/.ci/set-package-vars.js
           CI_CD_BUILD=1 cli/.ci/package.sh
@@ -58,7 +58,7 @@ jobs:
           fi
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Install the Apple certificate and provisioning profile
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:22.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+    apt-utils build-essential ca-certificates curl git p7zip-full p7zip nsis sudo
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
+    export NVM_DIR="$HOME/.nvm" && \
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && \
+    nvm install 20 && \
+    npm install -g yarn
+RUN git config --global --add safe.directory /build

--- a/cli/.ci/package.sh
+++ b/cli/.ci/package.sh
@@ -51,7 +51,11 @@ copy_lib sarif
 if [[ "$OS" == 'Darwin' ]]; then
   yarn package-macos
 else
+  mkdir -p tmp/artifacts
   yarn package-deb
+  cp dist/deb/* tmp/artifacts/
+  yarn package-win
+  cp dist/win32/* tmp/artifacts/
 fi
 
 if [ -n "${LINKED}" ]; then

--- a/cli/README.md
+++ b/cli/README.md
@@ -22,7 +22,7 @@ $ npm install -g @nowsecure/platform-cli
 $ ns-cli COMMAND
 running command...
 $ ns-cli (--version)
-@nowsecure/platform-cli/1.0.0 darwin-x64 node-v16.19.1
+@nowsecure/platform-cli/1.1.0 linux-x64 node-v20.16.0
 $ ns-cli --help [COMMAND]
 USAGE
   $ ns-cli COMMAND
@@ -86,7 +86,7 @@ DESCRIPTION
   Commands to manipulate applications for analysis
 ```
 
-_See code: [dist/commands/app/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.0.0/dist/commands/app/index.ts)_
+_See code: [dist/commands/app/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/app/index.ts)_
 
 ## `ns-cli app archive [PLATFORM] [PACKAGENAME]`
 
@@ -340,9 +340,9 @@ ARGUMENTS
 
 FLAGS
   -g, --group=<value>           Group name
-  -t, --analysis-type=<option>  The type of analysis to perform
+  -t, --analysis-type=<option>  The type of analysis to perform.
                                 <options: full|static|dependencies>
-  -v, --set-version=<value>     Set the version of the uploaded binary
+  -v, --set-version=<value>     Set the version of the uploaded binary.
   --group-ref=<value>           Group reference
 
 GLOBAL FLAGS
@@ -354,11 +354,33 @@ GLOBAL FLAGS
   --token=<value>        Platform API token
   --ui=<value>           URL of the UI server
 
-DESCRIPTION
-  Upload and analyze an application binary
-
 EXAMPLES
   $ ns-cli app process my_application.apk
+
+FLAG DESCRIPTIONS
+  -t, --analysis-type=full|static|dependencies  The type of analysis to perform.
+
+    "static": Perform a static analysis only.
+    "dependencies": Analyze the application's library dependencies.
+    "full": Run a complete assessment including dynamic analysis.
+
+    If the flag is not specified a full analysis will be run.
+
+    Static-only and dependency-only analyses do not attempt to decrypt encrypted binaries as
+    these analyses are intended to provide a rapid result for e.g. a CI/CD pipeline. An encrypted
+    binary will fail to analyze.
+
+    Please note:
+    The assessment status on NowSecure Platform UI does not reflect successful completion of
+    static-only or dependencies-only analysis. The labels in the UI will be "Partial Results"
+    and "Failed Dynamic Analysis" due to the lack of a dynamic analysis.
+
+  -v, --set-version=<value>  Set the version of the uploaded binary.
+
+    Attached a custom version string to the uploaded build,
+    overriding the version string contained in the package file.
+
+    The custom string will be displayed in the "Version" column of the application list in Platform.
 ```
 
 ## `ns-cli app update [PLATFORM] [PACKAGENAME] [STDIN]`
@@ -483,7 +505,7 @@ DESCRIPTION
   Commands to retrieve assessment data
 ```
 
-_See code: [dist/commands/assessment/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.0.0/dist/commands/assessment/index.ts)_
+_See code: [dist/commands/assessment/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/assessment/index.ts)_
 
 ## `ns-cli assessment cancel ASSESSMENT`
 
@@ -813,7 +835,7 @@ FLAGS
   --ui=<value>           URL of the UI server
 ```
 
-_See code: [dist/commands/configure/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.0.0/dist/commands/configure/index.ts)_
+_See code: [dist/commands/configure/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/configure/index.ts)_
 
 ## `ns-cli help [COMMANDS]`
 
@@ -847,7 +869,7 @@ DESCRIPTION
   Commands for the user's organization
 ```
 
-_See code: [dist/commands/organization/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.0.0/dist/commands/organization/index.ts)_
+_See code: [dist/commands/organization/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/organization/index.ts)_
 
 ## `ns-cli organization groups`
 
@@ -1244,7 +1266,7 @@ DESCRIPTION
   Commands for users & accounts
 ```
 
-_See code: [dist/commands/user/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.0.0/dist/commands/user/index.ts)_
+_See code: [dist/commands/user/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/user/index.ts)_
 
 ## `ns-cli user account`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -86,7 +86,7 @@ DESCRIPTION
   Commands to manipulate applications for analysis
 ```
 
-_See code: [dist/commands/app/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/app/index.ts)_
+_See code: [dist/commands/app/index.ts](https://github.com/nowsecure/nowsecure-cli/blob/v1.1.0/dist/commands/app/index.ts)_
 
 ## `ns-cli app archive [PLATFORM] [PACKAGENAME]`
 
@@ -505,7 +505,7 @@ DESCRIPTION
   Commands to retrieve assessment data
 ```
 
-_See code: [dist/commands/assessment/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/assessment/index.ts)_
+_See code: [dist/commands/assessment/index.ts](https://github.com/nowsecure/nowsecure-cli/blob/v1.1.0/dist/commands/assessment/index.ts)_
 
 ## `ns-cli assessment cancel ASSESSMENT`
 
@@ -835,7 +835,7 @@ FLAGS
   --ui=<value>           URL of the UI server
 ```
 
-_See code: [dist/commands/configure/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/configure/index.ts)_
+_See code: [dist/commands/configure/index.ts](https://github.com/nowsecure/nowsecure-cli/blob/v1.1.0/dist/commands/configure/index.ts)_
 
 ## `ns-cli help [COMMANDS]`
 
@@ -869,7 +869,7 @@ DESCRIPTION
   Commands for the user's organization
 ```
 
-_See code: [dist/commands/organization/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/organization/index.ts)_
+_See code: [dist/commands/organization/index.ts](https://github.com/nowsecure/nowsecure-cli/blob/v1.1.0/dist/commands/organization/index.ts)_
 
 ## `ns-cli organization groups`
 
@@ -1266,7 +1266,7 @@ DESCRIPTION
   Commands for users & accounts
 ```
 
-_See code: [dist/commands/user/index.ts](https://github.com/cosdon/nowsecure-cli/blob/v1.1.0/dist/commands/user/index.ts)_
+_See code: [dist/commands/user/index.ts](https://github.com/nowsecure/nowsecure-cli/blob/v1.1.0/dist/commands/user/index.ts)_
 
 ## `ns-cli user account`
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -6,10 +6,10 @@
   "bin": {
     "ns-cli": "./bin/run"
   },
-  "homepage": "https://github.com/cosdon/nowsecure-cli",
+  "homepage": "https://github.com/nowsecure/nowsecure-cli",
   "license": "MIT",
   "main": "dist/index.js",
-  "repository": "cosdon/nowsecure-cli",
+  "repository": "nowsecure/nowsecure-cli",
   "files": [
     "/bin",
     "/dist",
@@ -100,7 +100,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "bugs": "https://github.com/cosdon/nowsecure-cli/issues",
+  "bugs": "https://github.com/nowsecure/nowsecure-cli/issues",
   "keywords": [
     "oclif"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -97,7 +97,7 @@
     "link-deps": "yarn link @nowsecure/platform-lib @nowsecure/sarif @nowsecure/github-snapshot"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "bugs": "https://github.com/cosdon/nowsecure-cli/issues",
   "keywords": [

--- a/cli/package.json
+++ b/cli/package.json
@@ -91,6 +91,7 @@
     "prepack": "yarn build && oclif manifest && oclif readme",
     "package-macos": "oclif pack macos",
     "package-deb": "oclif pack deb",
+    "package-win": "oclif pack win",
     "make-package": ".ci/package.sh",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md",

--- a/cli/src/commands/configure/index.ts
+++ b/cli/src/commands/configure/index.ts
@@ -6,12 +6,12 @@ import { checkJWT, CliConfigFile, ConfigInput } from "../../utils";
 import inquirer, { DistinctQuestion } from "inquirer";
 
 function configPath(input: string | undefined) {
-  input = (input || "").trim() || "~/.nsclirc";
+  input = (input || "").trim() || path.join(os.homedir(), ".nsclirc");
   if (input === "~") {
     return os.homedir();
   }
   if (input.startsWith("~" + path.sep)) {
-    return os.homedir + input.substring(1);
+    return path.join(os.homedir(), input.substring(2));
   }
   return input;
 }

--- a/github-snapshot/package.json
+++ b/github-snapshot/package.json
@@ -15,7 +15,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "files": [
     "/lib"

--- a/lib/package.json
+++ b/lib/package.json
@@ -19,7 +19,7 @@
     "makedocs": "docs/makedocs.sh"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "files": [
     "/lib"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "make-package": "yarn run deps:dev && yarn run link && yarn run clean && yarn --cwd cli run link-deps && yarn --cwd cli run make-package"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   }
 }

--- a/sarif/package.json
+++ b/sarif/package.json
@@ -15,7 +15,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "files": [
     "/lib"


### PR DESCRIPTION
# Linux Builds

The CI build depends on the Microsoft Azure VM image for Ubuntu, which is far from a standard environment. ARM builds also require sudo and seem to assume that the build is being run as root in the first place.

This Dockerfile provides a fixed environment for building on Linux.

# Node 20

Building with Node 16 was failing with permission errors in `oclif`. Upgrading to Node 20 fixed this.

```
+ yarn package-deb
yarn run v1.22.22
$ oclif pack deb
 ›   Warning: oclif update available from 3.7.3 to 4.14.12.
oclif: gathering workspace for ns-cli to /build/cli/tmp/ns-cli
    Error: Command failed: npm pack --unsafe-perm
    /tmp/yarn--1722444948707-0.497377533169139/node: 3: exec: /root/.nvm/versions/node/v16.20.2/bin/node: Permission denied
    npm ERR! code 126
    npm ERR! path /build/cli
    npm ERR! command failed
    npm ERR! command sh -c -- yarn build && oclif manifest && oclif readme

    npm ERR! A complete log of this run can be found in:
    npm ERR!     /root/.npm/_logs/2024-07-31T16_55_49_476Z-debug-0.log

    Code: 126
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

# Windows Support

@1tacocat1's solution ran on Windows after fixing the builds, but existing path treatment was coded in a non-portable way, so it was failing to load the configuration. This is now fixed.

GitHub actions workflow was updated to include the dependencies for the Windows builds and to produce Windows artifacts.